### PR TITLE
Use only mark structure structure tracking

### DIFF
--- a/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
+++ b/projects/batfish/src/main/java/org/batfish/grammar/cisco/CiscoControlPlaneExtractor.java
@@ -2625,16 +2625,9 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   private void addIcmpTypeGroupReference(Variable_permissiveContext nameCtx) {
     String name = nameCtx.getText();
-    if (_configuration.getIcmpTypeObjectGroups().containsKey(name)) {
-      _currentIcmpTypeObjectGroup.getLines().add(new IcmpTypeGroupReferenceLine(name));
-      _configuration.referenceStructure(
-          ICMP_TYPE_OBJECT_GROUP,
-          name,
-          ICMP_TYPE_OBJECT_GROUP_GROUP_OBJECT,
-          nameCtx.start.getLine());
-    } else {
-      _configuration.getUndefinedIcmpTypeGroups().put(name, nameCtx.start.getLine());
-    }
+    _currentIcmpTypeObjectGroup.getLines().add(new IcmpTypeGroupReferenceLine(name));
+    _configuration.referenceStructure(
+        ICMP_TYPE_OBJECT_GROUP, name, ICMP_TYPE_OBJECT_GROUP_GROUP_OBJECT, nameCtx.start.getLine());
   }
 
   @Override
@@ -2653,13 +2646,9 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void exitOggn_group_object(Oggn_group_objectContext ctx) {
     String name = ctx.name.getText();
-    if (_configuration.getNetworkObjectGroups().containsKey(name)) {
-      _currentNetworkObjectGroup.getLines().add(new IpSpaceReference(name));
-      _configuration.referenceStructure(
-          NETWORK_OBJECT_GROUP, name, NETWORK_OBJECT_GROUP_GROUP_OBJECT, ctx.name.start.getLine());
-    } else {
-      _configuration.getUndefinedNetworkGroups().put(name, ctx.start.getLine());
-    }
+    _currentNetworkObjectGroup.getLines().add(new IpSpaceReference(name));
+    _configuration.referenceStructure(
+        NETWORK_OBJECT_GROUP, name, NETWORK_OBJECT_GROUP_GROUP_OBJECT, ctx.name.start.getLine());
   }
 
   @Override
@@ -2683,16 +2672,12 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
   @Override
   public void exitOggp_group_object(Oggp_group_objectContext ctx) {
     String name = ctx.name.getText();
-    if (_configuration.getProtocolObjectGroups().containsKey(name)) {
-      _currentProtocolObjectGroup.getLines().add(new ProtocolObjectGroupReferenceLine(name));
-      _configuration.referenceStructure(
-          PROTOCOL_OBJECT_GROUP,
-          name,
-          EXTENDED_ACCESS_LIST_PROTOCOL_OBJECT_GROUP,
-          ctx.name.start.getLine());
-    } else {
-      _configuration.getUndefinedProtocolGroups().put(name, ctx.start.getLine());
-    }
+    _currentProtocolObjectGroup.getLines().add(new ProtocolObjectGroupReferenceLine(name));
+    _configuration.referenceStructure(
+        PROTOCOL_OBJECT_GROUP,
+        name,
+        EXTENDED_ACCESS_LIST_PROTOCOL_OBJECT_GROUP,
+        ctx.name.start.getLine());
   }
 
   @Override
@@ -2716,7 +2701,7 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitOggs_group_object(Oggs_group_objectContext ctx) {
-    addServiceGroupreference(ctx.name);
+    addServiceGroupReference(ctx.name);
   }
 
   @Override
@@ -2879,23 +2864,19 @@ public class CiscoControlPlaneExtractor extends CiscoParserBaseListener
 
   @Override
   public void exitOgs_group_object(Ogs_group_objectContext ctx) {
-    addServiceGroupreference(ctx.name);
+    addServiceGroupReference(ctx.name);
   }
 
-  private void addServiceGroupreference(Variable_group_idContext nameCtx) {
+  private void addServiceGroupReference(Variable_group_idContext nameCtx) {
     String name = nameCtx.getText();
-    if (_configuration.getServiceObjectGroups().containsKey(name)) {
-      _currentServiceObjectGroup
-          .getLines()
-          .add(new ServiceObjectGroupReferenceServiceObjectGroupLine(name));
-      _configuration.referenceStructure(
-          SERVICE_OBJECT_GROUP,
-          name,
-          EXTENDED_ACCESS_LIST_SERVICE_OBJECT_GROUP,
-          nameCtx.start.getLine());
-    } else {
-      _configuration.getUndefinedServiceGroups().put(name, nameCtx.start.getLine());
-    }
+    _currentServiceObjectGroup
+        .getLines()
+        .add(new ServiceObjectGroupReferenceServiceObjectGroupLine(name));
+    _configuration.referenceStructure(
+        SERVICE_OBJECT_GROUP,
+        name,
+        EXTENDED_ACCESS_LIST_SERVICE_OBJECT_GROUP,
+        nameCtx.start.getLine());
   }
 
   @Override

--- a/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
+++ b/projects/batfish/src/main/java/org/batfish/representation/cisco/CiscoConfiguration.java
@@ -465,14 +465,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
 
   private transient Set<NamedBgpPeerGroup> _unusedPeerSessions;
 
-  private final SortedMap<String, Integer> _undefinedIcmpTypeGroups;
-
-  private final SortedMap<String, Integer> _undefinedNetworkGroups;
-
-  private final SortedMap<String, Integer> _undefinedProtocolGroups;
-
-  private final SortedMap<String, Integer> _undefinedServiceGroups;
-
   private ConfigurationFormat _vendor;
 
   private final Map<String, Vrf> _vrfs;
@@ -533,10 +525,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
     _tacacsServers = new TreeSet<>();
     _trackingGroups = new TreeMap<>();
     _undefinedPeerGroups = new TreeMap<>();
-    _undefinedIcmpTypeGroups = new TreeMap<>();
-    _undefinedNetworkGroups = new TreeMap<>();
-    _undefinedProtocolGroups = new TreeMap<>();
-    _undefinedServiceGroups = new TreeMap<>();
     _vrfs = new TreeMap<>();
     _vrfs.put(Configuration.DEFAULT_VRF_NAME, new Vrf(Configuration.DEFAULT_VRF_NAME));
     _vrrpGroups = new TreeMap<>();
@@ -956,22 +944,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
 
   public SortedMap<String, Integer> getUndefinedPeerGroups() {
     return _undefinedPeerGroups;
-  }
-
-  public SortedMap<String, Integer> getUndefinedIcmpTypeGroups() {
-    return _undefinedIcmpTypeGroups;
-  }
-
-  public SortedMap<String, Integer> getUndefinedNetworkGroups() {
-    return _undefinedNetworkGroups;
-  }
-
-  public SortedMap<String, Integer> getUndefinedProtocolGroups() {
-    return _undefinedProtocolGroups;
-  }
-
-  public SortedMap<String, Integer> getUndefinedServiceGroups() {
-    return _undefinedServiceGroups;
   }
 
   private Ip getUpdateSource(
@@ -3343,22 +3315,6 @@ public final class CiscoConfiguration extends VendorConfiguration {
         _undefinedPeerGroups,
         CiscoStructureType.BGP_PEER_GROUP,
         CiscoStructureUsage.BGP_NEIGHBOR_STATEMENT);
-    undefinedGroups(
-        _undefinedIcmpTypeGroups,
-        CiscoStructureType.ICMP_TYPE_OBJECT_GROUP,
-        CiscoStructureUsage.ICMP_TYPE_OBJECT_GROUP_GROUP_OBJECT);
-    undefinedGroups(
-        _undefinedNetworkGroups,
-        CiscoStructureType.NETWORK_OBJECT_GROUP,
-        CiscoStructureUsage.NETWORK_OBJECT_GROUP_GROUP_OBJECT);
-    undefinedGroups(
-        _undefinedProtocolGroups,
-        CiscoStructureType.PROTOCOL_OBJECT_GROUP,
-        CiscoStructureUsage.PROTOCOL_OBJECT_GROUP_GROUP_OBJECT);
-    undefinedGroups(
-        _undefinedServiceGroups,
-        CiscoStructureType.SERVICE_OBJECT_GROUP,
-        CiscoStructureUsage.SERVICE_OBJECT_GROUP_SERVICE_OBJECT);
 
     markConcreteStructure(
         CiscoStructureType.BFD_TEMPLATE, CiscoStructureUsage.INTERFACE_BFD_TEMPLATE);

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/asa-nested-icmp-type-object-group
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/asa-nested-icmp-type-object-group
@@ -16,7 +16,6 @@ object-group group icmp-type services
  group-object echo_group
  group-object unreachable_group
  group-object redirect_group
- group-object UNDEFINED_GROUP
 !
 object-group icmp-type mask_reply_group
  icmp-object mask-reply
@@ -25,3 +24,7 @@ object-group icmp-type mixed_group
  icmp-object mask-reply
  group-object mask_reply_group
  group-object UNDEFINED_GROUP_MIXED
+!
+object-group group icmp-type services_undef
+ group-object UNDEFINED_GROUP
+!

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/asa-nested-protocol-object-group
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/asa-nested-protocol-object-group
@@ -16,7 +16,6 @@ object-group group protocol protocols
  group-object proto1
  group-object proto2
  group-object proto3
- group-object UNDEFINED_GROUP
 !
 object-group protocol proto4
  protocol-object gre
@@ -25,4 +24,7 @@ object-group protocol mixed_group
  protocol-object igmp
  group-object proto4
  group-object UNDEFINED_GROUP_MIXED
+!
+object-group group protocol protocol_undef
+ group-object UNDEFINED_GROUP
 !

--- a/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/asa-nested-service-object-group
+++ b/projects/batfish/src/test/resources/org/batfish/grammar/cisco/testconfigs/asa-nested-service-object-group
@@ -16,7 +16,6 @@ object-group group service services tcp-udp
  group-object service1
  group-object service2
  group-object service3
- group-object UNDEFINED_GROUP
 !
 object-group service service4
  port-object eq 4444
@@ -25,4 +24,7 @@ object-group service mixed_group
  port-object eq 5555
  group-object service4
  group-object UNDEFINED_GROUP_MIXED
+!
+object-group group service services_undef tcp-udp
+ group-object UNDEFINED_GROUP
 !

--- a/tests/parsing-tests/unit-tests.ref
+++ b/tests/parsing-tests/unit-tests.ref
@@ -27913,7 +27913,7 @@
             "      OBJECT_GROUP:'object-group'  <== mode:DEFAULT_MODE",
             "      (og_service",
             "        SERVICE:'service'  <== mode:M_ObjectGroup",
-            "        name = (variable_permissive",
+            "        name = (variable_group_id",
             "          VARIABLE:'SVCGRP-ICMP'  <== mode:DEFAULT_MODE)",
             "        NEWLINE:'\\n'  <== mode:DEFAULT_MODE",
             "        (ogs_service_object",


### PR DESCRIPTION
Under the hood, `markConcreteStructure` handles calling `undefined` for any references it deems undefined, so we can skip explicitly tracking undefined structures.
